### PR TITLE
Add Ray serve example using AWS neuron-cores

### DIFF
--- a/examples/serve-inference/README.md
+++ b/examples/serve-inference/README.md
@@ -1,0 +1,83 @@
+This example compiles Open LLAMA-3B model and deploys the model on Trainium (Trn1)  instance
+using Ray Serve and FastAPI. It uses transformers-neuronx to shard the model across devices/neuron cores
+via Tensor parallelism. 
+
+
+## Setup 
+* Clone this repo to run the example on your local laptop:
+```
+git clone https://github.com/aws-samples/aws-samples-for-ray
+
+cd aws-samples-for-ray/examples/serve-inference
+```
+
+* Replace subnet and security-group where you intend to launch the cluster in `cluster-inference-serve.yaml`
+```
+sed -i 's/subnet-replace-me/subnet-ID/g' cluster-inference-serve.yaml
+sed -i 's/sg-replace-me/sg-ID/g' cluster-inference-serve.yaml
+```
+
+* Start your Ray cluster from your local laptop (pre-requisite of Ray installation):
+```
+ray up cluster-inference-serve.yaml
+```
+
+* Deploy the model using serve
+```
+ray exec cluster-inference-serve.yaml \
+'serve run aws_neuron_core_inference_serve:entrypoint --runtime-env-json='{"env_vars":{"NEURON_CC_FLAGS": "--model-type=transformer-inference", "FI_EFA_FORK_SAFE":"1"}}'' \
+--tmux
+```
+
+* Wait for the serve deployment to complete (typically takes ~5minutes)
+```
+ray exec cluster-inference-serve.yaml 'source aws_neuron_venv_pytorch/bin/activate && serve status'
+```
+Sample expected output of serve status
+```
+proxies:
+  proxy-uuid: HEALTHY
+applications:
+  default:
+    status: RUNNING
+    message: ''
+    last_deployed_time_s: 1694558868.7500472
+    deployments:
+      LlamaModel:
+        status: HEALTHY
+        replica_states:
+          RUNNING: 1
+        message: ''
+      APIIngress:
+        status: HEALTHY
+        replica_states:
+          RUNNING: 1
+        message: ''
+```
+
+
+## Usage
+Attach to the head node of the Ray cluster
+```
+ray attach cluster-inference-serve.yaml
+```
+
+Navigate to the python interpreter on head node
+```
+source aws_neuron_venv_pytorch/bin/activate && python
+```
+
+Start using the model
+```
+import requests
+
+response = requests.get(f"http://127.0.0.1:8000/infer?sentence=AWS is super cool")
+print(response.status_code, response.json())
+```
+
+## Teardown
+To teardown the cluster/resources
+```
+ray down cluster-inference-serve.yaml -y
+```
+

--- a/examples/serve-inference/aws_neuron_core_inference_serve.py
+++ b/examples/serve-inference/aws_neuron_core_inference_serve.py
@@ -1,0 +1,59 @@
+from fastapi import FastAPI  # noqa
+from ray import serve  # noqa
+
+import torch # noqa
+import os
+from transformers import AutoTokenizer # noqa
+
+app = FastAPI()
+
+hf_model = "openlm-research/open_llama_3b"
+local_model_path = "open_llama_3b_split"
+
+
+@serve.deployment(num_replicas=1)
+@serve.ingress(app)
+class APIIngress:
+    def __init__(self, llama_model_handle) -> None:
+        self.handle = llama_model_handle
+
+    @app.get("/infer")
+    async def infer(self, sentence: str):
+        ref = await self.handle.infer.remote(sentence)
+        result = await ref
+        return result
+
+
+@serve.deployment(
+    ray_actor_options={"resources": {"neuron_cores": 32},
+                       "runtime_env": {"env_vars": {"NEURON_CC_FLAGS": "--model-type=transformer-inference"}}},
+    autoscaling_config={"min_replicas": 1, "max_replicas": 1},
+)
+class LlamaModel:
+    def __init__(self):
+        import torch # noqa
+        from transformers import AutoTokenizer # noqa
+        from transformers_neuronx.llama.model import LlamaForSampling # noqa
+        from transformers import LlamaForCausalLM # noqa
+        from transformers_neuronx.module import save_pretrained_split # noqa
+
+        if not os.path.exists(local_model_path):
+            print(f"Saving model split for {hf_model} to local path {local_model_path}")
+            self.model = LlamaForCausalLM.from_pretrained(hf_model)
+            save_pretrained_split(self.model, local_model_path)
+        else:
+            print(f"Using existing model split {local_model_path}")
+
+        print(f"Loading and compiling model {local_model_path} for Neuron")
+        self.neuron_model = LlamaForSampling.from_pretrained(local_model_path, batch_size=1, tp_degree=32, amp='f16')
+        self.neuron_model.to_neuron()
+        self.tokenizer = AutoTokenizer.from_pretrained(hf_model)
+
+    def infer(self, sentence: str):
+        input_ids = self.tokenizer.encode(sentence, return_tensors="pt")
+        with torch.inference_mode():
+            generated_sequences = self.neuron_model.sample(input_ids, sequence_length=2048, top_k=50)
+        return [self.tokenizer.decode(seq) for seq in generated_sequences]
+
+
+entrypoint = APIIngress.bind(LlamaModel.bind())

--- a/examples/serve-inference/cluster-inference-serve.yaml
+++ b/examples/serve-inference/cluster-inference-serve.yaml
@@ -1,0 +1,110 @@
+cluster_name: inference-serve
+
+max_workers: 1
+
+# If a node is idle for this many minutes, it will be removed.
+idle_timeout_minutes: 60
+
+# Cloud-provider specific configuration.
+provider:
+  type: aws
+  region: us-west-2
+  # Availability zone(s), comma-separated, that nodes may be launched in.
+  # Nodes will be launched in the first listed availability zone and will
+  # be tried in the subsequent availability zones if launching fails.
+  availability_zone: us-west-2d
+  use_internal_ips: True
+  cache_stopped_nodes: False
+
+# How Ray will authenticate with newly launched nodes.
+auth:
+  ssh_user: ubuntu
+# By default Ray creates a new private keypair, but you can also use your own.
+# If you do so, make sure to also set "KeyName" in the head and worker node
+# configurations below.
+#    ssh_private_key: /path/to/your/key.pem
+
+# Tell the autoscaler the allowed node types and the resources they provide.
+# The key is the name of the node type, which is just for debugging purposes.
+# The node config specifies the launch config and physical instance type.
+available_node_types:
+  ray.head.default:
+    node_config:
+      InstanceType: trn1.32xlarge
+      ImageId: ami-0c65adc9a5c1b5d7c
+      EbsOptimized: True
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 512
+      NetworkInterfaces:
+        - DeviceIndex: 0
+          NetworkCardIndex: 0
+          SubnetId: subnet-replace-me
+          Groups:
+            - sg-replace-me
+
+# List of shell commands to run to set up nodes.
+setup_commands:
+  - sudo pkill -9 apt-get || true
+  - sudo pkill -9 dpkg || true
+  - sudo dpkg --configure -a
+  - |
+    . /etc/os-release
+    sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+    deb https://apt.repos.neuron.amazonaws.com ${VERSION_CODENAME} main
+    EOF
+  - wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+  - sudo apt-get update -y
+  - sudo apt-get install git -y
+  - sudo apt-get install linux-headers-$(uname -r) -y
+  - sudo apt-get install aws-neuronx-dkms=2.* -y --allow-change-held-packages
+  - sudo apt-get install aws-neuronx-collectives=2.* -y --allow-change-held-packages
+  - sudo apt-get install aws-neuronx-runtime-lib=2.* -y --allow-change-held-packages
+  - sudo apt-get install aws-neuronx-tools=2.* -y --allow-change-held-packages
+  - export PATH=/opt/aws/neuron/bin:$PATH
+  - sudo sed -i 'H;1h;$!d;x;/hard  *nofile/!s/$/\n* hard nofile 1000000/' /etc/security/limits.conf
+  - sudo sed -i 'H;1h;$!d;x;/soft  *nofile/!s/$/\n* soft nofile 1000000/' /etc/security/limits.conf
+  - sudo sed -i 's/^#*\(\*\|\s*\*\)\s*soft\s*nofile\s*[0-9]\+$/\1 soft nofile 1000000/' /etc/security/limits.conf
+  - sudo sed -i 's/^#*\(\*\|\s*\*\)\s*hard\s*nofile\s*[0-9]\+$/\1 hard nofile 1000000/' /etc/security/limits.conf
+  - sudo sed -i 's/^#*\(\*\|\s*\*\)\s*soft\s*nofile\s*[0-9]\+$/\1 soft nofile 1000000/' /etc/security/limits.d/01_efa.conf || true
+  - sudo sed -i 's/^#*\(\*\|\s*\*\)\s*hard\s*nofile\s*[0-9]\+$/\1 hard nofile 1000000/' /etc/security/limits.d/01_efa.conf || true
+  - sudo apt-get install -y python3.8-venv g++
+  - python3.8 -m venv aws_neuron_venv_pytorch
+  - |
+    source aws_neuron_venv_pytorch/bin/activate
+    python -m pip install -U pip
+    pip install ipykernel
+    python3.8 -m ipykernel install --user --name aws_neuron_venv_pytorch --display-name "Python (torch-neuronx)"
+    pip install jupyter notebook
+    pip install environment_kernels
+    python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
+    python -m pip install wget awscli regex
+    pip install -U neuronx-cc==2.* torch-neuronx torchvision "ray[air]==2.7.0rc0" transformers-neuronx sentencepiece
+    deactivate
+
+# Custom commands that will be run on the head node after common setup.
+head_setup_commands: []
+
+# Custom commands that will be run on the worker node after common setup.
+worker_setup_commands: []
+
+# Command to start ray on the head node. You don't need to change this.
+head_start_ray_commands:
+  - |
+    source aws_neuron_venv_pytorch/bin/activate
+    ray stop
+    ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+    deactivate
+
+# Command to start ray on worker nodes. You don't need to change this.
+worker_start_ray_commands:
+  - |
+    source aws_neuron_venv_pytorch/bin/activate
+    ray stop
+    ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+    deactivate
+
+head_node_type: ray.head.default
+file_mounts:
+  "~/aws_neuron_core_inference_serve.py": "~/aws_neuron_core_inference_serve.py"


### PR DESCRIPTION

*Description of changes:*

This example helps customers to launch a cluster for serving inference model using Ray serve. Apart from Ray documentation, this example provides
 1. Ray cluster with trainium instance launch and appropriate neuron-sdk commands
 2. Ray Serve example using Open LLAMA to compile and deploy the model.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
> I confirm
