### PR TITLE
updating distributed_rl code for sagemaker ray examples given ray 2.7.0

### DIFF
--- a/sagemaker/distributed_rl/distributed_cart_pole_rl.ipynb
+++ b/sagemaker/distributed_rl/distributed_cart_pole_rl.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "2a0c62f5",
    "metadata": {},
    "source": [
     "# Distributed RL Training Using Ray Framework with Cart Pole v1 Environment"
@@ -9,6 +10,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "06da4171",
    "metadata": {},
    "source": [
     "In this SageMaker Notebook we will walkthrough an example using the Cart Pole v1 Reinforcement Learning (RL) use case. This is a classic RL use case where the environment is created within the [OpenAI gym toolkit](https://github.com/openai/gym). You can read more about the Cart Pole use case and refer to the initial research paper by Barto, Sutton, and Anderson in the following [Gym Documentation](https://www.gymlibrary.dev/environments/classic_control/cart_pole/). \n",
@@ -27,6 +29,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cf767f6e",
    "metadata": {},
    "source": [
     "## Important Scripts\n",
@@ -43,6 +46,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3ce442c2",
    "metadata": {},
    "source": [
     "## Import Packages"
@@ -51,7 +55,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "09a2a27b",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from sagemaker.image_uris import get_training_image_uri\n",
@@ -60,6 +67,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "24ea35b3",
    "metadata": {},
    "source": [
     "__Review image uris to choose from for DLC__\n",
@@ -69,13 +77,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "ff7d6e65",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "image_uri = get_training_image_uri(framework=\"tensorflow\", \n",
     "                       region=\"us-east-1\",\n",
-    "                       py_version=\"py39\",\n",
-    "                       framework_version=\"2.8\",\n",
+    "                       py_version=\"py310\",\n",
+    "                       framework_version=\"2.12\",\n",
     "                       instance_type=\"ml.m5.4xlarge\"\n",
     "                      )\n",
     "\n",
@@ -84,6 +95,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "790264d6",
    "metadata": {},
    "source": [
     "## Train model with TensorFlow"
@@ -91,6 +103,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7dc69ed9",
    "metadata": {},
    "source": [
     "Change bucket name below if needed"
@@ -99,7 +112,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "0dd03ac3",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import uuid\n",
@@ -114,6 +130,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "72a36584",
    "metadata": {},
    "source": [
     "Below are metric definitions which will be reported in the CloudWatch Logs during the SageMaker Training Job. Ray will capture these metrics for each training iteration. "
@@ -122,21 +139,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "330b9cee",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "metric_definitions = [\n",
-    "    {'Name': 'episode_reward_mean', 'Regex': 'episode_reward_max: ([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'},\n",
-    "    {'Name': 'episode_reward_max', 'Regex': 'episode_reward_mean: ([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'}, \n",
-    "    {'Name': 'episode_reward_min', 'Regex': 'episode_reward_min: ([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'},\n",
-    "    {'Name': 'episodes_total', 'Regex': 'episodes_total: ([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'}, \n",
-    "    {'Name': 'training_iteration', 'Regex': 'training_iteration: ([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'},\n",
-    "    {'Name': 'timesteps_total', 'Regex': 'timesteps_total: ([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'}\n",
+    "    {'Name': 'episode_reward_mean', 'Regex': 'episode_reward_mean\\s+([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'},\n",
+    "    {'Name': 'episode_reward_max', 'Regex': 'episode_reward_max\\s+([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'}, \n",
+    "    {'Name': 'episode_reward_min', 'Regex': 'episode_reward_min\\s+([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'},\n",
+    "    {'Name': 'episodes_total', 'Regex': 'episodes_total\\s+([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'}, \n",
+    "    {'Name': 'training_iteration', 'Regex': 'training_iteration\\s+([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'},\n",
+    "    {'Name': 'timesteps_total', 'Regex': 'timesteps_total\\s+([-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?)'}\n",
     "]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "00d09b0f",
    "metadata": {},
    "source": [
     "In our example, we will setup a homogeneous cluster of 5 m5.4xlarge instances. __You may change this given your Amazon SageMaker Service Quota limit__. \n",
@@ -153,6 +174,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "577dfb55",
    "metadata": {},
    "source": [
     "*Note* - In our example we use a CPU instance type. You may use a GPU (e.g. ml.p3.2xlarge) instance given your use case or for testing. If you do use a GPU instance, be cognizant of your *num-workers* parameter and please refer to the [RLlib Scaling guide](https://docs.ray.io/en/latest/rllib/rllib-training.html#rllib-scaling-guide) for best recommendationsto configure *num_workers* and *num_gpus_per_worker*. You may need to modify the configurations in the __train_cart_pole.py__ file. "
@@ -161,7 +183,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "8b7bcca7",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# these variables are configured for a CPU instance types\n",
@@ -173,8 +198,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "84f28e6d",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -195,8 +222,8 @@
     "                     \"num_sgd_iter\": \"20\"\n",
     "                    },\n",
     "    instance_type=instance_type, # try with m5.4xlarge\n",
-    "    framework_version=\"2.8\",\n",
-    "    py_version=\"py39\",\n",
+    "    framework_version=\"2.12\",\n",
+    "    py_version=\"py310\",\n",
     "    checkpoint_s3_uri=tb_logging_path,\n",
     "    keep_alive_period_in_seconds=1800\n",
     ")\n",
@@ -206,6 +233,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ffb010a3",
    "metadata": {},
    "source": [
     "When Executing the Job, notice the format of the output for each iteration. This is based from Ray's tune.report class."
@@ -213,6 +241,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1272c0ca",
    "metadata": {},
    "source": [
     "## HPO Job\n",
@@ -223,7 +252,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "ede5757b",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# define arbitrary ranges\n",
@@ -237,6 +269,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "36d2164d",
    "metadata": {},
    "source": [
     "Here we create a SageMaker Hyperparameter Tuning Job. \n",
@@ -249,7 +282,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "358e55b1",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "tuner = HyperparameterTuner(\n",
@@ -267,19 +303,605 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "c032130b",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "tuner.fit(wait=False) # To reduce logs, we recommend setting this to True and reviewing logs in AWS console"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b159d83c-bb7e-4829-9135-889392b46c61",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "availableInstances": [
+   {
+    "_defaultOrder": 0,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.t3.medium",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 1,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.t3.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 2,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.t3.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 3,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.t3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 4,
+    "_isFastLaunch": true,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 5,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 6,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 7,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 8,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 9,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 10,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 11,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 12,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.m5d.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 13,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.m5d.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 14,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.m5d.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 15,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.m5d.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 16,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.m5d.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 17,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.m5d.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 18,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.m5d.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 19,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.m5d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 20,
+    "_isFastLaunch": false,
+    "category": "General purpose",
+    "gpuNum": 0,
+    "hideHardwareSpecs": true,
+    "memoryGiB": 0,
+    "name": "ml.geospatial.interactive",
+    "supportedImageNames": [
+     "sagemaker-geospatial-v1-0"
+    ],
+    "vcpuNum": 0
+   },
+   {
+    "_defaultOrder": 21,
+    "_isFastLaunch": true,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 4,
+    "name": "ml.c5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 22,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 8,
+    "name": "ml.c5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 23,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.c5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 24,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.c5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 25,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 72,
+    "name": "ml.c5.9xlarge",
+    "vcpuNum": 36
+   },
+   {
+    "_defaultOrder": 26,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 96,
+    "name": "ml.c5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 27,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 144,
+    "name": "ml.c5.18xlarge",
+    "vcpuNum": 72
+   },
+   {
+    "_defaultOrder": 28,
+    "_isFastLaunch": false,
+    "category": "Compute optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.c5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 29,
+    "_isFastLaunch": true,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g4dn.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 30,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g4dn.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 31,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g4dn.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 32,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g4dn.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 33,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g4dn.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 34,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g4dn.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 35,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 61,
+    "name": "ml.p3.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 36,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 244,
+    "name": "ml.p3.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 37,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 488,
+    "name": "ml.p3.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 38,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.p3dn.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 39,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.r5.large",
+    "vcpuNum": 2
+   },
+   {
+    "_defaultOrder": 40,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.r5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 41,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.r5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 42,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.r5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 43,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.r5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 44,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.r5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 45,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 512,
+    "name": "ml.r5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 46,
+    "_isFastLaunch": false,
+    "category": "Memory Optimized",
+    "gpuNum": 0,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.r5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 47,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 16,
+    "name": "ml.g5.xlarge",
+    "vcpuNum": 4
+   },
+   {
+    "_defaultOrder": 48,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 32,
+    "name": "ml.g5.2xlarge",
+    "vcpuNum": 8
+   },
+   {
+    "_defaultOrder": 49,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 64,
+    "name": "ml.g5.4xlarge",
+    "vcpuNum": 16
+   },
+   {
+    "_defaultOrder": 50,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 128,
+    "name": "ml.g5.8xlarge",
+    "vcpuNum": 32
+   },
+   {
+    "_defaultOrder": 51,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 1,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 256,
+    "name": "ml.g5.16xlarge",
+    "vcpuNum": 64
+   },
+   {
+    "_defaultOrder": 52,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 192,
+    "name": "ml.g5.12xlarge",
+    "vcpuNum": 48
+   },
+   {
+    "_defaultOrder": 53,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 4,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 384,
+    "name": "ml.g5.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 54,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 768,
+    "name": "ml.g5.48xlarge",
+    "vcpuNum": 192
+   },
+   {
+    "_defaultOrder": 55,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 56,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4de.24xlarge",
+    "vcpuNum": 96
+   }
+  ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-west-2:236514542706:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -291,7 +913,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/sagemaker/distributed_rl/src/requirements.txt
+++ b/sagemaker/distributed_rl/src/requirements.txt
@@ -1,7 +1,8 @@
-ray
-ray[rllib]
-ray[tune]
-gym
-dm-tree
-pygame
-tensorflow-probability==0.16.0
+ray==2.7.0
+ray[rllib]==2.7.0
+ray[tune]==2.7.0
+gymnasium==0.28.1
+dm-tree==0.1.8
+pygame==2.5.2
+protobuf==3.20.*
+tensorflow-probability==0.22.0


### PR DESCRIPTION
Made the following updates to distributed_rl ray sagemaker sample given Ray 2.7.0 updates:

- Added specific versions to the requirements.txt file to avoid dependencies/bugs when users try to run in the future
- Updated RLlib runtime training script given new updates for Ray's lates release 2.7.0
- Updated DLC to tensorflow 2.12 and py3.10
- Changed metric definitions since now using ray.train.report class
